### PR TITLE
deps: update go to 1.20, python to 3.11, and pytest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN true && \
 # Follow PEP 668 - Marking Python base environments as “externally managed”.
 RUN true && \
     python3 -m venv .venv && \
-    source .venv/bin/activate && \
+    . .venv/bin/activate && \
     pip install pip --upgrade && \
     pip install twine pre-commit && \
     pip3 install -r /src/requirements_test.txt && \
@@ -42,6 +42,7 @@ FROM base as test
 # Run unit tests
 COPY . /src
 RUN true && \
+    . .venv/bin/activate && \
     ./scripts/run_tests.sh && \
     RELEASE_DRY_RUN=true RELEASE_VERSION=0.0.0 \
         ./scripts/publish.sh && \
@@ -56,7 +57,10 @@ FROM test as release
 ARG PYPI_TOKEN
 ARG RELEASE_VERSION
 ARG RELEASE_DRY_RUN
-RUN ./scripts/publish.sh
+RUN true && \
+    . .venv/bin/activate && \
+    ./scripts/publish.sh && \
+    true
 
 ## Release Test ################################################################
 #
@@ -70,6 +74,7 @@ COPY ./tests /src/tests
 COPY ./scripts/run_tests.sh /src/scripts/run_tests.sh
 COPY ./scripts/install_release.sh /src/scripts/install_release.sh
 RUN true && \
+    . .venv/bin/activate && \
     ./scripts/install_release.sh && \
     ./scripts/run_tests.sh && \
     true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Base dependencies ########################################################################
-ARG GO_VERSION=1.19
+ARG GO_VERSION=1.20
 ARG PROTOBUF_VERSION=3.15.8
 
 FROM golang:${GO_VERSION} as base

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN true && \
     apt-get autoremove --yes && \
     apt-get install -y \
         unzip \
-        python3.9 \
         python3-pip && \
     apt-get upgrade -y && \
     pip install pip --upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,15 @@ RUN true && \
     apt-get autoremove --yes && \
     apt-get install -y \
         unzip \
-        python3-pip && \
+        python3.11 \
+        python3-pip \
+        python3-venv && \
     apt-get upgrade -y && \
+    true
+# Follow PEP 668 - Marking Python base environments as “externally managed”.
+RUN true && \
+    python3 -m venv .venv && \
+    source .venv/bin/activate && \
     pip install pip --upgrade && \
     pip install twine pre-commit && \
     pip3 install -r /src/requirements_test.txt && \

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-coverage==6.2
-pytest==6.2.3
+coverage==6.5
+pytest==6.2.5
 pytest-cov==2.10.1
 pytest-html==3.1.1
 


### PR DESCRIPTION
- Update Go to address CVEs (CVE-2023-29404, CVE-2023-29402, CVE-2023-29403, CVE-2023-29405)
- Use Python v3.11 (for Debian 12 it the built-in version)
   - Python3.9 no longer able to install, `E: Unable to locate package python3.9
   - Required updating pytest dependencies to work with 3.11, was getting error `TypeError: required field "lineno" missing from alias`
- Use virtual env for python package installs to follow [PEP 668](https://peps.python.org/pep-0668/) - Marking Python base environments as “externally managed”
   -  Build error - options are to use virtual env or to add flag `--break-system-packages`